### PR TITLE
Add validate method for echo verb

### DIFF
--- a/flickr-sdk.js
+++ b/flickr-sdk.js
@@ -63,6 +63,28 @@ FlickrRequest.prototype.plugin = function (plugin) {
 	return this;
 };
 
+/**
+ * Group of methods for working with the validation (`test`) endpoints of the Flickr API
+ * @function validate
+ * @memberof! FlickrRequest#
+ * @returns {object} verbs for working with validation
+ */
+FlickrRequest.prototype.validate = function () {
+	var request = this;
+
+	return {
+
+		/**
+		 * Echo a parameter back from the API
+		 * @memberof! FlickrRequest#
+		 * @function validate.echo
+		 * @returns {object} an echo'd response of the input
+		 */
+		echo: function () {
+			return request.sdk.transport.call(request.sdk.findDefinition(apiV1, 'echo'), { 'echo': 'hello world' }, {});
+		}
+	};
+};
 
 /**
  * Group of methods for working with media

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "backo": "^1.1.0",
     "deepmerge": "^0.2.10",
     "except": "^0.1.3",
-    "flickr-api-swagger": "2.2.1",
+    "flickr-api-swagger": "2.3.0",
     "indexof": "^0.0.1",
     "native-promise-only": "^0.8.1",
     "superagent": "1.8.3",

--- a/test/flickr-sdk.js
+++ b/test/flickr-sdk.js
@@ -164,6 +164,24 @@ describe('Flickr SDK', function () {
 	});
 
 	/**
+	 * Test echo
+	 */
+	it('should echo back parameters', function (done) {
+
+		var flickrSDK = new FlickrSDK(flickrAPIConfig);
+
+		flickrSDK
+			.request()
+			.validate()
+			.echo()
+			.then(function (response) {
+				assert.equal(response.body.echo._content, "hello world");
+				done();
+			});
+
+	});
+
+	/**
 	 * Param validation
 	 */
 	describe('param validation', function () {
@@ -285,8 +303,8 @@ describe('Flickr SDK', function () {
 				.request()
 				.media()
 				.post({
-					photo: './test/fixtures/test.png',
-					is_public: 'unicorn' // Not one of the allowed values
+					'photo': './test/fixtures/test.png',
+					'is_public': 'unicorn' // Not one of the allowed values
 				})
 				.then(null, function (err) {
 					assert.equal(err[0], "Param is_public with value unicorn not one of possible options: [0, 1]");

--- a/test/tapes/47d928014fb2f78a5180f44243152a31.js
+++ b/test/tapes/47d928014fb2f78a5180f44243152a31.js
@@ -1,0 +1,36 @@
+var path = require("path");
+
+/**
+ * GET /services/rest?test=value&oauth_consumer_key=68a62ca6dccd553ca49e069d4b68e92d&oauth_token=72157660394259366-112955b6c5659e6b&oauth_version=1.0&oauth_timestamp=499137600&oauth_nonce=fa0b22d0edb39252630a343f95b33988918a2e3d&oauth_signature_method=HMAC-SHA1&format=json&nojsoncallback=1&oauth_signature=x0DAi/RsJ/NwA9zxA7G8QKN6l68=&method=flickr.test.echo
+ *
+ * host: fts.flickr.vip.bf1.yahoo.com
+ * accept-encoding: gzip, deflate
+ * user-agent: node-superagent/1.8.3
+ * cookie: 
+ * connection: close
+ */
+
+module.exports = function (req, res) {
+  res.statusCode = 200;
+
+  res.setHeader("date", "Sun, 08 May 2016 23:02:54 GMT");
+  res.setHeader("content-type", "application/json");
+  res.setHeader("content-length", "332");
+  res.setHeader("p3p", "policyref=\"https://policies.yahoo.com/w3c/p3p.xml\", CP=\"CAO DSP COR CUR ADM DEV TAI PSA PSD IVAi IVDi CONi TELo OTPi OUR DELi SAMi OTRi UNRi PUBi IND PHY ONL UNI PUR FIN COM NAV INT DEM CNT STA POL HEA PRE LOC GOV\"");
+  res.setHeader("x-account-nsid", "95431477@N05");
+  res.setHeader("cache-control", "private");
+  res.setHeader("x-served-by", "www247.flickr.bf1.yahoo.com");
+  res.setHeader("vary", "Accept-Encoding");
+  res.setHeader("content-encoding", "gzip");
+  res.setHeader("age", "0");
+  res.setHeader("connection", "close");
+  res.setHeader("via", "http/1.1 fts120.flickr.bf1.yahoo.com (ApacheTrafficServer [cMsSf ])");
+  res.setHeader("server", "ATS");
+
+  res.setHeader("x-yakbak-tape", path.basename(__filename, ".js"));
+
+  res.write(new Buffer("H4sIAAAAAAAAA52SzU7DMBCE3yVn2jp2vLGROEQgUYGoBFwrRY6zoSE/rmKnFKq+O3EvVFY5wG2l/WZnx95D5NC66PoQ5dr0DvupjnaqHTE6XkVGjW7jG3bscMgb/AxIEAqoVlBqXXLOtEokEpBlUoBAScufIc402AfqlMY8BSBMJpRLBjCLYyo5L0Bz4BKh+NHvcLC1CSfEc3JmUXdTFtVtAyiRMmYpkDO0N73GAKsUKSgtCZYFk5RTYESxhFWSF4xJIWQsFEV2lsnWb71y44B5h25jymDg8im7nb0us9grKjN0Knzodzslmpq98ZVWbVso3YQZLxgGyJ7cZfV68WIf1ovVRya/9ll6L54fV9CCuPH6iwtWba2bYe4vYI56YzyotnV+8qptfjK9tI2H/ncMXjml+PP+v96Qb06f7kvTRMdvlp3Uh9ACAAA=", "base64"));
+  res.end();
+
+  return __filename;
+};

--- a/test/tapes/cd1b4b8da669b6f98557434ee9d6d701.js
+++ b/test/tapes/cd1b4b8da669b6f98557434ee9d6d701.js
@@ -1,0 +1,36 @@
+var path = require("path");
+
+/**
+ * GET /services/rest?echo=hello world&oauth_consumer_key=68a62ca6dccd553ca49e069d4b68e92d&oauth_token=72157660394259366-112955b6c5659e6b&oauth_version=1.0&oauth_timestamp=499137600&oauth_nonce=fa0b22d0edb39252630a343f95b33988918a2e3d&oauth_signature_method=HMAC-SHA1&format=json&nojsoncallback=1&oauth_signature=tjTKNJpO/QoD5RyIZ3+abCtyLdE=&method=flickr.test.echo
+ *
+ * host: fts.flickr.vip.bf1.yahoo.com
+ * accept-encoding: gzip, deflate
+ * user-agent: node-superagent/1.8.3
+ * cookie: 
+ * connection: close
+ */
+
+module.exports = function (req, res) {
+  res.statusCode = 200;
+
+  res.setHeader("date", "Sun, 08 May 2016 23:10:38 GMT");
+  res.setHeader("content-type", "application/json");
+  res.setHeader("content-length", "339");
+  res.setHeader("p3p", "policyref=\"https://policies.yahoo.com/w3c/p3p.xml\", CP=\"CAO DSP COR CUR ADM DEV TAI PSA PSD IVAi IVDi CONi TELo OTPi OUR DELi SAMi OTRi UNRi PUBi IND PHY ONL UNI PUR FIN COM NAV INT DEM CNT STA POL HEA PRE LOC GOV\"");
+  res.setHeader("x-account-nsid", "95431477@N05");
+  res.setHeader("cache-control", "private");
+  res.setHeader("x-served-by", "www-bm001.flickr.bf1.yahoo.com");
+  res.setHeader("vary", "Accept-Encoding");
+  res.setHeader("content-encoding", "gzip");
+  res.setHeader("age", "0");
+  res.setHeader("connection", "close");
+  res.setHeader("via", "http/1.1 fts113.flickr.bf1.yahoo.com (ApacheTrafficServer [cMsSf ])");
+  res.setHeader("server", "ATS");
+
+  res.setHeader("x-yakbak-tape", path.basename(__filename, ".js"));
+
+  res.write(new Buffer("H4sIAAAAAAAAA52SSU/DMBCF/wryFVpiO3biShyqglR2sZwQUuRlQtIsrhIXVFX978S9EFnlALeR5nvz5tmzQ6ALi2Y7lGnbOmgdmqEC6tqefNmuNmh/hqzcuMK3+00DXVbBNuB5KjnRkhutDWNUy1hAxIWJFU9BkNEQZytoA3VCMEs4j6iICROU8wnGRDCmuGacCeDqR/8JXV/acAKeRiOLsoHeyWYdQLEQmCY8GqGtbTUEWC4jRYiJwCgqCCOcRpLGNBdMUSrSVOBUEqCjTH350Uq36SBrwBXWBAOX9/PF5GU5x16R266RLiBW/ZBoaLbWV1rWtZK6CjMeMQwQt3q9fbhZP76fP9lL9ry9fqOnUi3c9s5cXXj50f3yutRVN3XDo00PtzCAcl1mB6uyzw6ex5bx0P9uwSuHEH9d/9cL8s3hy31pK7T/BvzprdfUAgAA", "base64"));
+  res.end();
+
+  return __filename;
+};


### PR DESCRIPTION
The Flickr API has a couple validation endpoints, under flickr.test.  I think `test` is an ambiguous namespace and that validation is better suited.

I also pass a fixed parameter name and echo value in through this method, since exposing it to arbitrary parameter values doesn't serve a purpose.

I added a test, and also cleaned up a js-hint issue in the test.

Addresses: https://github.com/flickr/flickr/issues/1